### PR TITLE
수정:File-management Ver 1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.1.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDER=HIGH
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
     username: sa
     password: password
   jpa:
@@ -11,7 +11,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+        dialect: org.hibernate.dialect.H2Dialect
     open-in-view: true
   h2:
     console:


### PR DESCRIPTION
- 변경한 내용:
  * springdoc-openapi-starter-webmvc-ui 버전 3.1.0 → 2.8.6 변경 (존재하지 않는 버전 수정)
  * H2 URL에서 DEFAULT_NULL_ORDER=HIGH 설정 제거 (H2 2.4.240 미지원)
  * Hibernate dialect를 PostgreSQLDialect → H2Dialect로 변경

- 변경 이유:
  * springdoc 3.1.0 버전이 Maven Central에 존재하지 않아 빌드 실패
  * H2 2.4.240에서 DEFAULT_NULL_ORDER 설정 미지원으로 애플리케이션 시작 실패

- 주요 파일:
  * build.gradle
  * src/main/resources/application-local.yml